### PR TITLE
Détection du sous type 01.17.21

### DIFF
--- a/ParserIO.Core/Functions.cs
+++ b/ParserIO.Core/Functions.cs
@@ -3442,6 +3442,10 @@ namespace ParserIO.Core
                                 {
                                     result = result + ".10"; //01.17.10
                                 }
+                                else if (ai2 == "21")
+                                {
+                                    result = result + ".21"; //01.17.21
+                                }
                                 else if (ai2 == "30")
                                 {
                                     result = result + ".30"; //01.17.30


### PR DESCRIPTION
Le serial est bien reconnu dans la méthode Serial() mais pas dans le méthode SubType(). Cette correction permet de bien récupérer le serial avec une séquence 01.17.21
Résoud le bug : [Subtype 01.17.21 non reconnu](https://github.com/reseauphast/ParserIO/issues/1)